### PR TITLE
fix scrolling bug with none English url anchor

### DIFF
--- a/src/mixin/scrolling.js
+++ b/src/mixin/scrolling.js
@@ -58,7 +58,7 @@ export const scrollMixin = C =>
     // If no hash is provided, scroll to the top instead.
     scrollHashIntoView(hash, options) {
       if (hash) {
-        const el = document.getElementById(hash.substr(1));
+        const el = document.getElementById(decodeURIComponent(hash.substr(1)));
         if (el) el.scrollIntoView(options);
         else if (process.env.DEBUG) console.warn(`Can't find element with id ${hash}`);
       } else {


### PR DESCRIPTION
In previous implementation, the anchor like " #%E6%B7%BB%E5%8A%A0%E4%B8%80%E4%B8%AA-toc" can not get the correct element.